### PR TITLE
Fix TrustedHTML error

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,11 @@ if (GM_getValue === undefined)
 if (GM_setValue === undefined)
   GM_setValue = GM.setValue
 
+if (window.trustedTypes && window.trustedTypes.createPolicy) {
+  window.trustedTypes.createPolicy('default', {
+    createHTML: (string, sink) => string
+  });
+}
 
 //////////////////////////////////////////////////////////////
 /////  STYLE  ////////////////////////////////////////////////


### PR DESCRIPTION
Fixed: "Uncaught TypeError: Failed to set the 'innerHTML' property on 'Element': This document requires 'TrustedHTML' assignment".

Source: **hacker09**'s response on GreasyFork: https://greasyfork.org/en/discussions/development/220765-this-document-requires-trustedhtml-assignment